### PR TITLE
Simple CDI/Camel eventing bridge endpoints, see Javadoc of CdiEvent

### DIFF
--- a/envs/se/src/main/java/org/apache/camel/cdi/se/bean/EventConsumingRoute.java
+++ b/envs/se/src/main/java/org/apache/camel/cdi/se/bean/EventConsumingRoute.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.cdi.se.bean;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.cdi.CdiEvent;
+import org.apache.camel.cdi.Uri;
+import org.apache.camel.component.mock.MockEndpoint;
+
+import javax.inject.Inject;
+
+public class EventConsumingRoute extends RouteBuilder {
+
+    @Inject
+    @Uri(CdiEvent.CDI_EVENT_URI)
+    private Endpoint allCdiEventsEndpoint;
+
+    @Inject
+    @Uri("mock:resultAll")
+    private MockEndpoint resultAllEndpoint;
+
+    @Inject
+    @Uri("mock:resultBean")
+    private MockEndpoint resultBeanEndpoint;
+
+    @Inject
+    @Uri("mock:resultString")
+    private MockEndpoint resultStringEndpoint;
+
+    @Override
+    public void configure() {
+        from(allCdiEventsEndpoint).to(resultAllEndpoint);
+
+        from(CdiEvent.endpoint(SampleBean.class))
+            .to(resultBeanEndpoint);
+
+        from(CdiEvent.endpoint(String.class))
+            .to(resultStringEndpoint);
+
+    }
+}

--- a/envs/se/src/main/java/org/apache/camel/cdi/se/bean/SampleBean.java
+++ b/envs/se/src/main/java/org/apache/camel/cdi/se/bean/SampleBean.java
@@ -1,0 +1,35 @@
+package org.apache.camel.cdi.se.bean;
+
+public class SampleBean {
+
+    protected String label;
+
+    public SampleBean(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        SampleBean that = (SampleBean) o;
+
+        if (!label.equals(that.label)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return label.hashCode();
+    }
+}

--- a/envs/se/src/test/java/org/apache/camel/cdi/se/EventComponentTest.java
+++ b/envs/se/src/test/java/org/apache/camel/cdi/se/EventComponentTest.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.cdi.se;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.cdi.CdiCamelExtension;
+import org.apache.camel.cdi.CdiEvent;
+import org.apache.camel.cdi.Uri;
+import org.apache.camel.cdi.se.bean.EventConsumingRoute;
+import org.apache.camel.cdi.se.bean.SampleBean;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied;
+
+@RunWith(Arquillian.class)
+public class EventComponentTest {
+
+    @Deployment
+    public static Archive<?> deployment() {
+        return ShrinkWrap.create(JavaArchive.class)
+            // Camel CDI
+            .addPackage(CdiCamelExtension.class.getPackage())
+            // Test class
+            .addClass(EventConsumingRoute.class)
+            // Bean archive deployment descriptor
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
+    @Uri(CdiEvent.CDI_EVENT_URI)
+    private ProducerTemplate inbound;
+
+    @Inject
+    Event<SampleBean> sampleBeanEvent;
+
+    @Inject
+    @Uri("mock:resultAll")
+    private MockEndpoint outboundAll;
+
+    @Inject
+    @Uri("mock:resultBean")
+    private MockEndpoint outboundBean;
+
+    @Inject
+    @Uri("mock:resultString")
+    private MockEndpoint outboundString;
+
+    @Test
+    @InSequence(1)
+    public void startCamelContext(CamelContext context, List<Class> events) throws Exception {
+        context.start();
+    }
+
+    @Test
+    @InSequence(2)
+    public void sendMessageToInbound(List<Class> events) throws InterruptedException {
+        outboundAll.expectedMessageCount(4);
+        outboundAll.expectedBodiesReceived(1234, new SampleBean("foo"), new SampleBean("bar"), "test");
+
+        outboundBean.expectedMessageCount(2);
+        outboundBean.expectedBodiesReceived(new SampleBean("foo"), new SampleBean("bar"));
+
+        outboundString.expectedMessageCount(1);
+        outboundString.expectedBodiesReceived("test");
+
+        inbound.sendBody(1234);
+        inbound.sendBody(new SampleBean("foo"));
+        sampleBeanEvent.fire(new SampleBean("bar"));
+        inbound.sendBody("test");
+
+        assertIsSatisfied(2L, TimeUnit.SECONDS, outboundAll);
+        assertIsSatisfied(2L, TimeUnit.SECONDS, outboundBean);
+        assertIsSatisfied(2L, TimeUnit.SECONDS, outboundString);
+    }
+
+    @Test
+    @InSequence(3)
+    public void stopCamelContext(CamelContext context, List<Class> events) throws Exception {
+        context.stop();
+    }
+}

--- a/impl/src/main/java/org/apache/camel/cdi/CdiCamelExtension.java
+++ b/impl/src/main/java/org/apache/camel/cdi/CdiCamelExtension.java
@@ -106,6 +106,12 @@ public class CdiCamelExtension implements Extension {
     private void addDefaultCamelContext(@Observes AfterBeanDiscovery abd, BeanManager manager) {
         if (manager.getBeans(CamelContext.class, AnyLiteral.INSTANCE).isEmpty())
             abd.addBean(new CdiCamelContextBean(manager));
+
+        CdiEventComponent eventComponent = new CdiEventComponent(manager);
+        // Camel sends and receives events through this component, looked up by name
+        abd.addBean(eventComponent);
+        // CDI sends events to observer methods
+        abd.addObserverMethod(eventComponent);
     }
 
     private void camelEventNotifiers(@Observes ProcessObserverMethod<? extends EventObject, ?> pom) {

--- a/impl/src/main/java/org/apache/camel/cdi/CdiEvent.java
+++ b/impl/src/main/java/org/apache/camel/cdi/CdiEvent.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.cdi;
+
+/**
+ * <p>
+ * Consume all CDI events with this endpoint and route them to Camel dynamically,
+ * based on event (payload) type. Additional qualifiers are currently not supported,
+ * only the desired event (payload) type can be constrained.
+ * </p>
+ * <p>
+ * Produce and fire CDI events in Camel exchanges with this destination endpoint.
+ * The exchange input message body is the event type and payload. You will get an
+ * exception if the declared type of the producing endpoint doesn't match the
+ * message payload. An <code>Annotation[]</code> of additional qualifiers
+ * can be added as message header {@link #CDI_EVENT_QUALIFIERS}.
+ * </p>
+ * <p>
+ * Usage: <code>cdi-event://some.event.CustomType</code> or all with <code>cdi-event:///</code>
+ * </p>
+ * <p>
+ * Alternatively, call {@link CdiEvent#endpoint(Class)} to generate the string.
+ * </p>
+ * <p>
+ *     TODO: Support <code>@Inject @Uri(CDI_EVENT_URI) @SomeQualifier Endpoint|ProducerTemplate</code>
+ * </p>
+ *
+ * @author Christian Bauer
+ */
+public final class CdiEvent {
+
+    public static final String CDI_EVENT = "cdi-event";
+    public static final String CDI_EVENT_URI = CDI_EVENT + ":///";
+    public static final String CDI_EVENT_QUALIFIERS = "CamelCdiQualifiers";
+
+    public static String endpoint() {
+        return endpoint(null);
+    }
+
+    public static String endpoint(Class<?> clazz) {
+        return CDI_EVENT + "://" + (clazz != null ? clazz.getName() : "") + "/";
+    }
+
+}

--- a/impl/src/main/java/org/apache/camel/cdi/CdiEventComponent.java
+++ b/impl/src/main/java/org/apache/camel/cdi/CdiEventComponent.java
@@ -1,0 +1,207 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.cdi;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.impl.DefaultComponent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.event.Reception;
+import javax.enterprise.event.TransactionPhase;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Default;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.enterprise.inject.spi.ObserverMethod;
+import javax.enterprise.util.AnnotationLiteral;
+import javax.inject.Singleton;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.*;
+
+/**
+ * @author Christian Bauer
+ */
+public class CdiEventComponent
+    extends DefaultComponent
+    implements Bean<CdiEventComponent>, ObserverMethod {
+
+    private final Logger logger = LoggerFactory.getLogger(CdiEventComponent.class);
+
+    final protected BeanManager beanManager;
+    final protected Map<Class, Set<CdiEventEndpoint>> endpoints = new HashMap<>();
+
+    public CdiEventComponent(BeanManager beanManager) {
+        this.beanManager = beanManager;
+    }
+
+    public BeanManager getBeanManager() {
+        return beanManager;
+    }
+
+    @Override
+    public Class<?> getBeanClass() {
+        return CdiEventComponent.class;
+    }
+
+    @Override
+    public Type getObservedType() {
+        return Object.class;
+    }
+
+    @Override
+    public Set<Annotation> getObservedQualifiers() {
+        return new HashSet<Annotation>() {{
+            add(new AnnotationLiteral<Any>() {
+            });
+        }};
+    }
+
+    @Override
+    public Reception getReception() {
+        return Reception.ALWAYS;
+    }
+
+    @Override
+    public TransactionPhase getTransactionPhase() {
+        return TransactionPhase.IN_PROGRESS;
+    }
+
+    @Override
+    public Set<InjectionPoint> getInjectionPoints() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public boolean isNullable() {
+        return false;
+    }
+
+    @Override
+    public Set<Type> getTypes() {
+        Set<Type> types = new HashSet<Type>();
+        types.add(CdiEventComponent.class);
+        types.add(Object.class);
+        return types;
+    }
+
+    @Override
+    public Set<Annotation> getQualifiers() {
+        return new HashSet<Annotation>() {{
+            add(new AnnotationLiteral<Any>() {
+            });
+            add(new AnnotationLiteral<Default>() {
+            });
+        }};
+    }
+
+    @Override
+    public Class<? extends Annotation> getScope() {
+        return Singleton.class;
+    }
+
+    @Override
+    public String getName() {
+        return CdiEvent.CDI_EVENT;
+    }
+
+    @Override
+    public Set<Class<? extends Annotation>> getStereotypes() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public boolean isAlternative() {
+        return false;
+    }
+
+    @Override
+    public CdiEventComponent create(CreationalContext<CdiEventComponent> creationalContext) {
+        return this;
+    }
+
+    @Override
+    public void destroy(CdiEventComponent instance, CreationalContext<CdiEventComponent> creationalContext) {
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void notify(Object o) {
+        try {
+            Set<CdiEventEndpoint> destinationEndpoints = new HashSet<>();
+
+            // Block only for finding the endpoints
+            synchronized (endpoints) {
+                logger.debug("Handling CDI event of type '{}', possible endpoints: {}", o.getClass().getName(), endpoints.size());
+                for (Map.Entry<Class, Set<CdiEventEndpoint>> entry : endpoints.entrySet()) {
+                    if (entry.getKey().isAssignableFrom(o.getClass()))
+                        destinationEndpoints.addAll(entry.getValue());
+                }
+            }
+
+            // Then notify them after leaving the monitor
+            for (CdiEventEndpoint destinationEndpoint : destinationEndpoints) {
+                logger.debug("Found endpoint handling event (super)type '{}': {}", o.getClass().getName(), destinationEndpoint);
+                destinationEndpoint.notify(o);
+            }
+
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
+        logger.debug("New endpoint for URI: {}, remaining: {}, parameters: {}", new Object[] {uri, remaining, parameters});
+        if (remaining == null || remaining.length() == 0 || "/".equals(remaining)) {
+            logger.info("Creating new catchall (java.lang.Object) event endpoint");
+            return createEndpoint(Object.class, uri);
+        } else {
+            remaining = remaining.endsWith("/") ? remaining.substring(0, remaining.length() - 1) : remaining;
+            logger.info("Creating new endpoint for event type: {}", remaining);
+            Class type = CdiEventComponent.class.getClassLoader().loadClass(remaining);
+            return createEndpoint(type, uri);
+        }
+    }
+
+    protected <T> CdiEventEndpoint<T> createEndpoint(Class<T> type, String uri) throws Exception {
+        return new CdiEventEndpoint<T>(type, uri, this);
+    }
+
+    public void registerEndpoint(CdiEventEndpoint endpoint) {
+        synchronized (endpoints) {
+            Set<CdiEventEndpoint> registered = endpoints.get(endpoint.getType());
+            if (registered == null) {
+                registered = new HashSet<>();
+                endpoints.put(endpoint.getType(), registered);
+            }
+            registered.add(endpoint);
+        }
+    };
+
+    public void unregisterEndpoint(CdiEventEndpoint endpoint) {
+        synchronized (endpoints) {
+            if (endpoints.containsKey(endpoint.getType()))
+                endpoints.get(endpoint.getType()).remove(endpoint);
+        }
+    };
+}
+

--- a/impl/src/main/java/org/apache/camel/cdi/CdiEventEndpoint.java
+++ b/impl/src/main/java/org/apache/camel/cdi/CdiEventEndpoint.java
@@ -1,0 +1,163 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.cdi;
+
+import org.apache.camel.Component;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.impl.DefaultConsumer;
+import org.apache.camel.impl.DefaultEndpoint;
+import org.apache.camel.impl.DefaultProducer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.inject.spi.BeanManager;
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Christian Bauer
+ */
+public class CdiEventEndpoint<T> extends DefaultEndpoint {
+
+    static private final Logger logger = LoggerFactory.getLogger(CdiEventEndpoint.class);
+
+    public static class Consumer<T> extends DefaultConsumer {
+
+        public Consumer(CdiEventEndpoint<T> endpoint, Processor processor) {
+            super(endpoint, processor);
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public CdiEventEndpoint<T> getEndpoint() {
+            return (CdiEventEndpoint<T>) super.getEndpoint();
+        }
+
+        @Override
+        protected void doStart() throws Exception {
+            super.doStart();
+            getEndpoint().registerConsumer(this);
+        }
+
+        @Override
+        protected void doStop() throws Exception {
+            getEndpoint().unregisterConsumer(this);
+            super.doStop();
+        }
+
+        public void notify(T event) throws Exception {
+            Exchange exchange = getEndpoint().createExchange();
+            exchange.getIn().setBody(event);
+            getProcessor().process(exchange);
+        }
+    }
+
+    public static class Producer<T> extends DefaultProducer {
+
+        public Producer(CdiEventEndpoint<T> endpoint) {
+            super(endpoint);
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public CdiEventEndpoint<T> getEndpoint() {
+            return (CdiEventEndpoint<T>) super.getEndpoint();
+        }
+
+        @Override
+        public void process(Exchange exchange) throws Exception {
+            BeanManager beanManager = getEndpoint().getComponent().getBeanManager();
+            Annotation[] qualifiers = exchange.getIn().getHeader(CdiEvent.CDI_EVENT_QUALIFIERS, Annotation[].class);
+            Object event = exchange.getIn().getBody();
+            if (!getEndpoint().getType().isAssignableFrom(event.getClass())) {
+                throw new Exception(
+                    "Exchange body of type '" + event.getClass().getName() + "'" +
+                        " is not of destination endpoint event type: " + getEndpoint().getType()
+                );
+            }
+            logger.debug("Firing CDI event of type '{}' with qualifiers: {} ", event.getClass().getName(), Arrays.toString(qualifiers));
+            beanManager.fireEvent(event, qualifiers != null ? qualifiers : new Annotation[0]);
+        }
+    }
+
+    final protected Class<T> type;
+    final protected List<Consumer<T>> consumers = new ArrayList<>();
+
+    public CdiEventEndpoint(Class<T> type, String endpointUri, Component component) {
+        super(endpointUri, component);
+        this.type = type;
+    }
+
+    public Class<?> getType() {
+        return type;
+    }
+
+    @Override
+    public Consumer<T> createConsumer(Processor processor) throws Exception {
+        return new Consumer<T>(this, processor);
+    }
+
+    @Override
+    public Producer<T> createProducer() throws Exception {
+        return new Producer<T>(this);
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return true;
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+        getComponent().registerEndpoint(this);
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        getComponent().unregisterEndpoint(this);
+        super.doStop();
+    }
+
+    @Override
+    public CdiEventComponent getComponent() {
+        return (CdiEventComponent) super.getComponent();
+    }
+
+    public void registerConsumer(Consumer<T> consumer) {
+        synchronized (consumers) {
+            consumers.add(consumer);
+        }
+    }
+
+    public void unregisterConsumer(Consumer<T> consumer) {
+        synchronized (consumers) {
+            consumers.remove(consumer);
+        }
+    }
+
+    public void notify(T t) throws Exception {
+        synchronized (consumers) {
+            for (Consumer<T> consumer : consumers) {
+                consumer.notify(t);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is already an improvement compared with the patch in https://issues.apache.org/jira/browse/CAMEL-5408

Next step would be to register ObserverMethods specific for all discovered @Uri @SomeQualifier injection points.

Beyond that some parser/generator DSL would be nice, so you could specify "cdi-event://some.BeanType?qualifier=some.OtherType&qualifier=more.CustomQualifiers" as endpoint URL.